### PR TITLE
Improve array index matching

### DIFF
--- a/src/utils/pathExtraction.ts
+++ b/src/utils/pathExtraction.ts
@@ -36,10 +36,8 @@ export const findPathForSelectedText = (
   matchingPath = paths.find(path => {
     const pathLower = path.toLowerCase();
     // Match patterns like "accounts[0].image.name" when searching for "name"
-    return pathLower.includes(`].${cleanText}`) || 
-           pathLower.includes(`[0].${cleanText}`) ||
-           pathLower.includes(`[1].${cleanText}`) ||
-           pathLower.includes(`[2].${cleanText}`);
+    const indexRegex = new RegExp(`\\[\\d+\\]\\.${cleanText.replace(/[.*+?^${}()|[\\]\\]/g, '\\$&')}`);
+    return pathLower.includes(`].${cleanText}`) || indexRegex.test(pathLower);
   });
   
   if (matchingPath) return matchingPath;


### PR DESCRIPTION
## Summary
- support any numeric index in path extraction by using a regex

## Testing
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687a47ecac608332a22ddce9bee8fe2f