### PR TITLE
Fix README heading punctuation

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ npm run dev
 
 ## What technologies are used for this project?
 
-This project is built with .
+This project is built with:
 
 - Vite
 - TypeScript


### PR DESCRIPTION
## Summary
- fix punctuation for technology list in README

## Testing
- `npm run lint` *(fails: many lint errors)*
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_687a47eea8448332868ede628b3cba68